### PR TITLE
Utilisation de DateTimeFormatter au lieu de SimpleDateFormat

### DIFF
--- a/src/main/java/org/esupportail/sgc/services/userinfos/UserInfoService.java
+++ b/src/main/java/org/esupportail/sgc/services/userinfos/UserInfoService.java
@@ -24,6 +24,9 @@ import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -85,10 +88,10 @@ public class UserInfoService {
 	}
 	
 	
-	private SimpleDateFormat dateUTCsecFormatter = new SimpleDateFormat(DATE_FORMAT_UTCSEC_LDAP);
+	private DateTimeFormatter dateTimeUTCsecFormatter = DateTimeFormatter.ofPattern(DATE_FORMAT_UTCSEC_LDAP);
 	
-	protected SimpleDateFormat getDateUTCsecFormatter() {
-		return dateUTCsecFormatter;
+	protected DateTimeFormatter getDateTimeUTCsecFormatter() {
+		return dateTimeUTCsecFormatter;
 	}
 
 	
@@ -396,7 +399,7 @@ public class UserInfoService {
 		if(dateString!=null && !dateString.isEmpty()) {
 			log.trace("parsing of date : " + dateString);
 			try {
-				date = getDateUTCsecFormatter().parse(dateString);
+				date = Date.from(LocalDateTime.parse(dateString, getDateTimeUTCsecFormatter()).atZone(ZoneId.systemDefault()).toInstant());
 			} catch (Exception e) {
 				log.warn("parsing of date " + dateString + " failed", e);
 			}

--- a/src/main/java/org/esupportail/sgc/tools/DateUtils.java
+++ b/src/main/java/org/esupportail/sgc/tools/DateUtils.java
@@ -1,7 +1,9 @@
 package org.esupportail.sgc.tools;
 
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 import org.slf4j.Logger;
@@ -17,7 +19,7 @@ public class DateUtils {
 	
 	private final static String DATE_FORMAT_SCHACBIRTH_LDAP = "yyyyMMdd";
 	
-	private SimpleDateFormat dateFormatterSchacOfBirth = new SimpleDateFormat(DATE_FORMAT_SCHACBIRTH_LDAP);
+	private DateTimeFormatter dateTimeFormatterSchacOfBirth = DateTimeFormatter.ofPattern(DATE_FORMAT_SCHACBIRTH_LDAP);
 	
 	private SimpleDateFormat dateFormatterFr = new SimpleDateFormat(DATE_FORMAT_FR);
 
@@ -36,9 +38,9 @@ public class DateUtils {
 		if(dateString!=null && !dateString.isEmpty()) {
 			log.trace("parsing of date : " + dateString);
 			try {
-				date = dateFormatterSchacOfBirth.parse(dateString);
-			} catch (ParseException | NumberFormatException e) {
-				log.error("parsing of date " + dateString + " failed");
+				date = Date.from(LocalDate.parse(dateString, dateTimeFormatterSchacOfBirth).atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
+			} catch (Exception e) {
+				log.error("parsing of date " + dateString + " failed " + e.getMessage());
 			}
 		}
 		return date;


### PR DESCRIPTION
Utilisation de DateTimeFormatter au lieu de SimpleDateFormat qui n'est pas threadsafe (provoque une erreur dans Admin>Tools sync de masse => java.lang.NumberFormatException: For input string: ".E0")