### PR TITLE
ESC : gestion du cas SE-0000 : Access denied lors d'un getEscPerson

### DIFF
--- a/src/main/java/org/esupportail/sgc/services/esc/ApiEscService.java
+++ b/src/main/java/org/esupportail/sgc/services/esc/ApiEscService.java
@@ -156,7 +156,18 @@ public class ApiEscService extends ValidateService {
 				log.info("No Esc Person found on API for " + eppn);
 				return null;
 			} else {
-				throw clientEx;
+				try {
+					EscError escError = (EscError) new ObjectMapper().readValue(clientEx.getResponseBodyAsByteArray(), EscError.class);
+					if("SE-0000".equals(escError.getCode())) {
+						log.info("SE-0000 : " + escError.getMessage() + " for " + eppn);
+						return null;
+					} else {
+						throw clientEx;
+					}
+				} catch (IOException e) {
+					log.trace("Error parsing response body as EscError - " + clientEx.getResponseBodyAsString(), e);
+					throw clientEx;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Dans le cas d'une erreur SE-0000 dans getEscPerson(), la fonction renvoie null afin qu'il y ait une tentative de création de la personne sur le router ESC, ce qui a pour effet d'associer la personne avec l'institution locale.