### PR TITLE
Update UserInfoService.java : correction problème si institute présent mais null

### DIFF
--- a/src/main/java/org/esupportail/sgc/services/userinfos/UserInfoService.java
+++ b/src/main/java/org/esupportail/sgc/services/userinfos/UserInfoService.java
@@ -424,7 +424,7 @@ public class UserInfoService {
             LocalDateTime dateFinDroits = appliConfigService.getDefaultDateFinDroits();
 			user.setDueDate(dateFinDroits);
 		} 
-		if(!userInfos.containsKey("institute") || (userInfos.get("institute")).isEmpty()) {
+		if(!userInfos.containsKey("institute") || userInfos.get("institute") == null || (userInfos.get("institute")).isEmpty()) {
 			user.setInstitute(user.getEppn().replaceAll(".*@", ""));
 		}
 	}


### PR DESCRIPTION
Problème survenu côté Unistra lors de la synchronisation de cas purgés du LDAP et remontant sans informations.