### PR TITLE
UserInfoService.java : academicLevel vidé si vide dans la source

### DIFF
--- a/src/main/java/org/esupportail/sgc/services/userinfos/UserInfoService.java
+++ b/src/main/java/org/esupportail/sgc/services/userinfos/UserInfoService.java
@@ -325,6 +325,9 @@ public class UserInfoService {
 				if(academicLevel != null && !academicLevel.isEmpty()) {
 					user.setAcademicLevel(Long.valueOf(academicLevel));
 				}
+				else {
+					user.setAcademicLevel(null);
+				}
 			} else if("pic".equalsIgnoreCase(key)) {
 				String pic = userInfos.get("pic");
 				user.setPic(pic);


### PR DESCRIPTION
Le champ academicLevel restait présent dans esup-sgc lorsqu'il n'était plus présent dans la source, ce qui faisait que certains dossiers apparaissaient chaque jour dans les synchros.